### PR TITLE
Disable inResponseTo checks and tests

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -92,7 +92,12 @@ func (m *Middleware) ServeMetadata(w http.ResponseWriter, r *http.Request) {
 
 func (m *Middleware) GetAssertion(r *http.Request) (*saml.Assertion, error) {
 	r.ParseForm()
-	assertion, err := m.ServiceProvider.ParseResponse(r, m.getPossibleRequestIDs(r))
+
+//  TODO:  restore this after
+//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
+//	TODO: assertion, err := m.ServiceProvider.ParseResponse(r, m.getPossibleRequestIDs(r))
+
+	assertion, err := m.ServiceProvider.ParseResponse(r, make([]string, 0))
 	if err != nil {
 		if parseErr, ok := err.(*saml.InvalidResponseError); ok {
 			m.ServiceProvider.Logger.Printf("RESPONSE: ===\n%s\n===\nNOW: %s\nERROR: %s",

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -395,7 +395,10 @@ func (test *MiddlewareTest) TestCanParseResponse(c *C) {
 
 	resp := httptest.NewRecorder()
 	test.Middleware.ServeHTTP(resp, req)
-	c.Assert(resp.Code, Equals, http.StatusFound)
+
+	//  TODO:  restore this after
+	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
+	//	TODO: c.Assert(resp.Code, Equals, http.StatusFound)
 
 	c.Assert(resp.Header().Get("Location"), Equals, "/frob")
 	c.Assert(resp.Header()["Set-Cookie"], DeepEquals, []string{

--- a/service_provider.go
+++ b/service_provider.go
@@ -408,7 +408,10 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		return nil, retErr
 	}
 
-	requestIDvalid := false
+	requestIDvalid := true
+	//  TODO:  restore this after
+	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
+	//  TODO: requestIDvalid := false
 	for _, possibleRequestID := range possibleRequestIDs {
 		if resp.InResponseTo == possibleRequestID {
 			requestIDvalid = true
@@ -509,16 +512,18 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 		return fmt.Errorf("issuer is not %q", sp.IDPMetadata.EntityID)
 	}
 	for _, subjectConfirmation := range assertion.Subject.SubjectConfirmations {
-		requestIDvalid := false
-		for _, possibleRequestID := range possibleRequestIDs {
-			if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
-				requestIDvalid = true
-				break
-			}
-		}
-		if !requestIDvalid {
-			return fmt.Errorf("SubjectConfirmation one of the possible request IDs (%v)", possibleRequestIDs)
-		}
+		//  TODO:  restore this after
+		//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
+		//TODO: requestIDvalid := false
+		//TODO: for _, possibleRequestID := range possibleRequestIDs {
+		//TODO: 	if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
+		//TODO: 		requestIDvalid = true
+		//TODO: 		break
+		//TODO: 	}
+		//TODO: }
+		//TODO: if !requestIDvalid {
+		//TODO: 	return fmt.Errorf("SubjectConfirmation one of the possible request IDs (%v)", possibleRequestIDs)
+		//TODO: }
 		if subjectConfirmation.SubjectConfirmationData.Recipient != sp.AcsURL.String() {
 			return fmt.Errorf("SubjectConfirmation Recipient is not %s", sp.AcsURL.String())
 		}

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -670,7 +670,10 @@ func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 
 	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
 	_, err = s.ParseResponse(&req, []string{"wrongRequestID"})
-	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
+
+	//  TODO:  restore this after
+	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
+	//	TODO: c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
 
 	TimeNow = func() time.Time {
 		rv, _ := time.Parse("Mon Jan 2 15:04:05 MST 2006", "Mon Nov 30 20:57:09 UTC 2016")
@@ -754,7 +757,9 @@ func (test *ServiceProviderTest) TestInvalidAssertions(c *C) {
 
 	pretty.Print(assertion.Subject.SubjectConfirmations)
 	err = s.validateAssertion(&assertion, []string{"any request id"}, TimeNow())
-	c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
+	//  TODO:  restore this after
+	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
+// TODO:	c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
 
 	assertion.Subject.SubjectConfirmations[0].SubjectConfirmationData.Recipient = "wrong/acs/url"
 	err = s.validateAssertion(&assertion, []string{"id-9e61753d64e928af5a7a341a97f420c9"}, TimeNow())


### PR DESCRIPTION
## What ##
Disabled the inResponseTo checks, along with the tests.

## Why ##
The library assumes that the same instance that sends out the SAML request will receive the SAML response.  This is not the case for supernova.  In the super short term, we will disable the inResponseTo checks, so that responses that go to a different supernova will not fail.  Note that for the IDP initiated flow, inResponseTo is blank, so there are legitimate use cases where inResponseTo is not checked.

We do have a story to make inResponseTo checks work across supernovas.
https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto

### Testing ###
Ran the modified tests.  Tested on local dev setup.
