### PR TITLE
Fix nameid-formats, update Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
     "testsaml",
     "xmlenc"
   ]
-  revision = "e231b7a1204a93c343c1a5fa2374ca2f6572f715"
+  revision = "d3df7a77410edbc4434e7c26ff5b5f262294855e"
   source = "github.com/sagansystems/saml"
 
 [[projects]]

--- a/service_provider.go
+++ b/service_provider.go
@@ -34,9 +34,9 @@ func (n NameIDFormat) Element() *etree.Element {
 
 // Name ID formats
 const (
-	UnspecifiedNameIDFormat  NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
+	UnspecifiedNameIDFormat  NameIDFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
 	TransientNameIDFormat    NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-	EmailAddressNameIDFormat NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"
+	EmailAddressNameIDFormat NameIDFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 	PersistentNameIDFormat   NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
 )
 


### PR DESCRIPTION
## What ##
Fix noncompliant nameid-formats, update the self-referential Gopkg.lock.

## Testing ##
Ran tests, also tested with Azure AD setup.
