### PR TITLE
Restore InResponseTo checks, but log instead of failing if they do not pass

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -92,12 +92,7 @@ func (m *Middleware) ServeMetadata(w http.ResponseWriter, r *http.Request) {
 
 func (m *Middleware) GetAssertion(r *http.Request) (*saml.Assertion, error) {
 	r.ParseForm()
-
-//  TODO:  restore this after
-//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
-//	TODO: assertion, err := m.ServiceProvider.ParseResponse(r, m.getPossibleRequestIDs(r))
-
-	assertion, err := m.ServiceProvider.ParseResponse(r, make([]string, 0))
+	assertion, err := m.ServiceProvider.ParseResponse(r, m.getPossibleRequestIDs(r))
 	if err != nil {
 		if parseErr, ok := err.(*saml.InvalidResponseError); ok {
 			m.ServiceProvider.Logger.Printf("RESPONSE: ===\n%s\n===\nNOW: %s\nERROR: %s",

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -395,10 +395,7 @@ func (test *MiddlewareTest) TestCanParseResponse(c *C) {
 
 	resp := httptest.NewRecorder()
 	test.Middleware.ServeHTTP(resp, req)
-
-	//  TODO:  restore this after
-	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
-	//	TODO: c.Assert(resp.Code, Equals, http.StatusFound)
+	c.Assert(resp.Code, Equals, http.StatusFound)
 
 	c.Assert(resp.Header().Get("Location"), Equals, "/frob")
 	c.Assert(resp.Header()["Set-Cookie"], DeepEquals, []string{

--- a/service_provider.go
+++ b/service_provider.go
@@ -408,10 +408,7 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		return nil, retErr
 	}
 
-	requestIDvalid := true
-	//  TODO:  restore this after
-	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
-	//  TODO: requestIDvalid := false
+	requestIDvalid := false
 	for _, possibleRequestID := range possibleRequestIDs {
 		if resp.InResponseTo == possibleRequestID {
 			requestIDvalid = true
@@ -512,18 +509,16 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 		return fmt.Errorf("issuer is not %q", sp.IDPMetadata.EntityID)
 	}
 	for _, subjectConfirmation := range assertion.Subject.SubjectConfirmations {
-		//  TODO:  restore this after
-		//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
-		//TODO: requestIDvalid := false
-		//TODO: for _, possibleRequestID := range possibleRequestIDs {
-		//TODO: 	if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
-		//TODO: 		requestIDvalid = true
-		//TODO: 		break
-		//TODO: 	}
-		//TODO: }
-		//TODO: if !requestIDvalid {
-		//TODO: 	return fmt.Errorf("SubjectConfirmation one of the possible request IDs (%v)", possibleRequestIDs)
-		//TODO: }
+		requestIDvalid := false
+		for _, possibleRequestID := range possibleRequestIDs {
+			if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
+				requestIDvalid = true
+				break
+			}
+		}
+		if !requestIDvalid {
+			return fmt.Errorf("SubjectConfirmation one of the possible request IDs (%v)", possibleRequestIDs)
+		}
 		if subjectConfirmation.SubjectConfirmationData.Recipient != sp.AcsURL.String() {
 			return fmt.Errorf("SubjectConfirmation Recipient is not %s", sp.AcsURL.String())
 		}

--- a/service_provider.go
+++ b/service_provider.go
@@ -415,8 +415,9 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		}
 	}
 	if !requestIDvalid {
-		retErr.PrivateErr = fmt.Errorf("`InResponseTo` does not match any of the possible request IDs (expected %v)", possibleRequestIDs)
-		return nil, retErr
+		sp.Logger.Printf("InResponseTo [%v] does not match any of the possible request IDs [expected %v]", resp.InResponseTo, possibleRequestIDs)
+		// TODO restore after troubleshooting: retErr.PrivateErr = fmt.Errorf("`InResponseTo` does not match any of the possible request IDs (expected %v)", possibleRequestIDs)
+		// TODO restore after troubleshooting: return nil, retErr
 	}
 
 	if resp.IssueInstant.Add(MaxIssueDelay).Before(now) {
@@ -517,7 +518,9 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 			}
 		}
 		if !requestIDvalid {
-			return fmt.Errorf("SubjectConfirmation one of the possible request IDs (%v)", possibleRequestIDs)
+			sp.Logger.Printf("SubjectConfirmation InResponseTo [%v] is not one of the possible request IDs [%v]", subjectConfirmation.SubjectConfirmationData.InResponseTo, possibleRequestIDs)
+
+			// TODO restore after troubleshooting: return fmt.Errorf("SubjectConfirmation InResponseTo is not one of the possible request IDs (%v)", possibleRequestIDs)
 		}
 		if subjectConfirmation.SubjectConfirmationData.Recipient != sp.AcsURL.String() {
 			return fmt.Errorf("SubjectConfirmation Recipient is not %s", sp.AcsURL.String())

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -10,8 +10,7 @@ import (
 	"time"
 
 	"github.com/crewjam/saml/testsaml"
-	"github.com/kr/pretty"
-	dsig "github.com/russellhaering/goxmldsig"
+		"github.com/russellhaering/goxmldsig"
 
 	"crypto/rsa"
 
@@ -668,9 +667,10 @@ func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`Destination` does not match AcsURL (expected \"https://wrong/saml2/acs\")")
 	s.AcsURL = mustParseURL("https://15661444.ngrok.io/saml2/acs")
 
-	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
-	_, err = s.ParseResponse(&req, []string{"wrongRequestID"})
-	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
+	// TODO: restore after troubleshooting
+	//req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
+	//_, err = s.ParseResponse(&req, []string{"wrongRequestID"})
+	//c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
 
 	TimeNow = func() time.Time {
 		rv, _ := time.Parse("Mon Jan 2 15:04:05 MST 2006", "Mon Nov 30 20:57:09 UTC 2016")
@@ -752,9 +752,10 @@ func (test *ServiceProviderTest) TestInvalidAssertions(c *C) {
 	assertion = Assertion{}
 	xml.Unmarshal(assertionBuf, &assertion)
 
-	pretty.Print(assertion.Subject.SubjectConfirmations)
-	err = s.validateAssertion(&assertion, []string{"any request id"}, TimeNow())
-	c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
+	// TODO: restore after troubleshooting
+	//pretty.Print(assertion.Subject.SubjectConfirmations)
+	//err = s.validateAssertion(&assertion, []string{"any request id"}, TimeNow())
+	//c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
 
 	assertion.Subject.SubjectConfirmations[0].SubjectConfirmationData.Recipient = "wrong/acs/url"
 	err = s.validateAssertion(&assertion, []string{"id-9e61753d64e928af5a7a341a97f420c9"}, TimeNow())

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -670,10 +670,7 @@ func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 
 	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
 	_, err = s.ParseResponse(&req, []string{"wrongRequestID"})
-
-	//  TODO:  restore this after
-	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
-	//	TODO: c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
+	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
 
 	TimeNow = func() time.Time {
 		rv, _ := time.Parse("Mon Jan 2 15:04:05 MST 2006", "Mon Nov 30 20:57:09 UTC 2016")
@@ -757,9 +754,7 @@ func (test *ServiceProviderTest) TestInvalidAssertions(c *C) {
 
 	pretty.Print(assertion.Subject.SubjectConfirmations)
 	err = s.validateAssertion(&assertion, []string{"any request id"}, TimeNow())
-	//  TODO:  restore this after
-	//  TODO: https://app.clubhouse.io/gladly/story/18062/cache-saml-request-ids-across-supernovas-so-that-any-supernova-can-validate-inresponseto
-// TODO:	c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
+	c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
 
 	assertion.Subject.SubjectConfirmations[0].SubjectConfirmationData.Recipient = "wrong/acs/url"
 	err = s.validateAssertion(&assertion, []string{"id-9e61753d64e928af5a7a341a97f420c9"}, TimeNow())


### PR DESCRIPTION
## What ##
Restore InResponseTo checks.  Do not fail the SAML response if they fail, just log.
This reenables the checks that were disabled in https://github.com/sagansystems/saml/pull/4

## Why ##
During SAML SSO development, we saw these checks failing intermittently on master, but not on local (single-supernova) dev setups.  We need to determine if these failures are still occurring.  For some reason I got it in my head that the state was stored locally in the server, when in fact it was stored via cookies.  Will test on mastertest5 once this change (and the corresponding one for supernova deps) are merged.  Will determine next steps after reviewing what was logged.

## Testing ##
No special testing required.