### PR TITLE
Add compatibility flag for empty Destination

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -35,6 +35,7 @@ type Options struct {
 	ForceAuthn        bool
 	MetadataPath      string
 	ACSPath           string
+	Compatibility     saml.IdpCompatibility
 }
 
 // New creates a new Middleware
@@ -65,13 +66,14 @@ func New(opts Options) (*Middleware, error) {
 
 	m := &Middleware{
 		ServiceProvider: saml.ServiceProvider{
-			Key:         opts.Key,
-			Logger:      logr,
-			Certificate: opts.Certificate,
-			MetadataURL: metadataURL,
-			AcsURL:      acsURL,
-			IDPMetadata: opts.IDPMetadata,
-			ForceAuthn:  &opts.ForceAuthn,
+			Key:           opts.Key,
+			Logger:        logr,
+			Certificate:   opts.Certificate,
+			MetadataURL:   metadataURL,
+			AcsURL:        acsURL,
+			IDPMetadata:   opts.IDPMetadata,
+			ForceAuthn:    &opts.ForceAuthn,
+			Compatibility: opts.Compatibility,
 		},
 		AllowIDPInitiated: opts.AllowIDPInitiated,
 		TokenMaxAge:       tokenMaxAge,

--- a/service_provider.go
+++ b/service_provider.go
@@ -81,6 +81,9 @@ type ServiceProvider struct {
 	// ForceAuthn allows you to force re-authentication of users even if the user
 	// has a SSO session at the IdP.
 	ForceAuthn *bool
+
+	// Compatibility allows you to support not fully SAML-compliant IdPs
+	Compatibility IdpCompatibility
 }
 
 // MaxIssueDelay is the longest allowed time between when a SAML assertion is
@@ -403,7 +406,7 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %s", err)
 		return nil, retErr
 	}
-	if resp.Destination != sp.AcsURL.String() {
+	if !(resp.Destination == "" && sp.Compatibility.AllowEmptyDestination) && resp.Destination != sp.AcsURL.String() {
 		retErr.PrivateErr = fmt.Errorf("`Destination` does not match AcsURL (expected %q)", sp.AcsURL.String())
 		return nil, retErr
 	}
@@ -677,4 +680,9 @@ func (sp *ServiceProvider) validateSignature(el *etree.Element) error {
 
 	_, err = validationContext.Validate(el)
 	return err
+}
+
+type IdpCompatibility struct {
+	// AllowEmptyDestination allows for empty `Destiniation` field in the assertion
+	AllowEmptyDestination bool
 }

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -5,12 +5,13 @@ import (
 	"encoding/xml"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/crewjam/saml/testsaml"
-		"github.com/russellhaering/goxmldsig"
+	"github.com/russellhaering/goxmldsig"
 
 	"crypto/rsa"
 
@@ -640,6 +641,28 @@ func (test *ServiceProviderTest) TestCanParseResponse(c *C) {
 		},
 	})
 }
+
+func (test *ServiceProviderTest) TestEmptyDestinationAllowed(c *C) {
+	s := ServiceProvider{
+		Key:           test.Key,
+		Certificate:   test.Certificate,
+		MetadataURL:   mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
+		AcsURL:        mustParseURL("https://15661444.ngrok.io/saml2/acs"),
+		IDPMetadata:   &EntityDescriptor{},
+		Compatibility: IdpCompatibility{AllowEmptyDestination: true},
+	}
+	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
+	c.Assert(err, IsNil)
+
+	samlResponse := destinationRegExp.ReplaceAllString(test.SamlResponse, "")
+
+	req := http.Request{PostForm: url.Values{}}
+	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(samlResponse)))
+	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
+	c.Assert(err, IsNil)
+}
+
+var destinationRegExp = regexp.MustCompile(`Destination=\S+ `)
 
 func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 	s := ServiceProvider{


### PR DESCRIPTION
**What**
- Add compatibility flags with AllowEmptyDestination
- Allow missing Destination in assertion if AllowEmptyDestination is true

**Why**
To be able to support assertions from Porsche PPN

This commit supports [ch28791]