### PR TITLE
Implement partial destination matching

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/beevik/etree"
@@ -406,7 +407,7 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %s", err)
 		return nil, retErr
 	}
-	if !(resp.Destination == "" && sp.Compatibility.AllowEmptyDestination) && resp.Destination != sp.AcsURL.String() {
+	if resp.Destination != sp.AcsURL.String() && !(sp.Compatibility.AllowPartialDestination && strings.HasPrefix(sp.AcsURL.String(), resp.Destination)) {
 		retErr.PrivateErr = fmt.Errorf("`Destination` does not match AcsURL (expected %q)", sp.AcsURL.String())
 		return nil, retErr
 	}
@@ -683,6 +684,6 @@ func (sp *ServiceProvider) validateSignature(el *etree.Element) error {
 }
 
 type IdpCompatibility struct {
-	// AllowEmptyDestination allows for empty `Destiniation` field in the assertion
-	AllowEmptyDestination bool
+	// AllowPartialDestination allows for partial or empty `Destination` attribute in SAML response
+	AllowPartialDestination bool
 }

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -642,14 +642,14 @@ func (test *ServiceProviderTest) TestCanParseResponse(c *C) {
 	})
 }
 
-func (test *ServiceProviderTest) TestEmptyDestinationAllowed(c *C) {
+func (test *ServiceProviderTest) TestAllowPartialDestination(c *C) {
 	s := ServiceProvider{
 		Key:           test.Key,
 		Certificate:   test.Certificate,
 		MetadataURL:   mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
 		AcsURL:        mustParseURL("https://15661444.ngrok.io/saml2/acs"),
 		IDPMetadata:   &EntityDescriptor{},
-		Compatibility: IdpCompatibility{AllowEmptyDestination: true},
+		Compatibility: IdpCompatibility{AllowPartialDestination: true},
 	}
 	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
 	c.Assert(err, IsNil)
@@ -657,6 +657,13 @@ func (test *ServiceProviderTest) TestEmptyDestinationAllowed(c *C) {
 	samlResponse := destinationRegExp.ReplaceAllString(test.SamlResponse, "")
 
 	req := http.Request{PostForm: url.Values{}}
+	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(samlResponse)))
+	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
+	c.Assert(err, IsNil)
+
+	samlResponse = destinationRegExp.ReplaceAllString(test.SamlResponse, `Destination="https://15661444.ngrok.io"`)
+
+	req = http.Request{PostForm: url.Values{}}
 	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(samlResponse)))
 	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
 	c.Assert(err, IsNil)


### PR DESCRIPTION
**What**
Replace AllowEmptyDestination compatibility flag with AllowPartialDestination to allow prefix matching of the Destination

**Why**
Under certain circumstances PPN IdP could send partial destination.
For example, https://porsche-dev.gladly.qa was observed where https://porsche-dev.gladly.qa/saml/acs was expected

This change implements [ch29474]