### PR TITLE
Restore response validation for InResponseTo request id mismatch

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -419,9 +419,8 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		}
 	}
 	if !requestIDvalid {
-		sp.Logger.Printf("InResponseTo [%v] does not match any of the possible request IDs [expected %v]", resp.InResponseTo, possibleRequestIDs)
-		// TODO restore after troubleshooting: retErr.PrivateErr = fmt.Errorf("`InResponseTo` does not match any of the possible request IDs (expected %v)", possibleRequestIDs)
-		// TODO restore after troubleshooting: return nil, retErr
+		retErr.PrivateErr = fmt.Errorf("`InResponseTo` does not match any of the possible request IDs (expected %v)", possibleRequestIDs)
+		return nil, retErr
 	}
 
 	if resp.IssueInstant.Add(MaxIssueDelay).Before(now) {
@@ -532,9 +531,7 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 			}
 		}
 		if !requestIDvalid {
-			sp.Logger.Printf("SubjectConfirmation InResponseTo [%v] is not one of the possible request IDs [%v]", subjectConfirmation.SubjectConfirmationData.InResponseTo, possibleRequestIDs)
-
-			// TODO restore after troubleshooting: return fmt.Errorf("SubjectConfirmation InResponseTo is not one of the possible request IDs (%v)", possibleRequestIDs)
+			return fmt.Errorf("SubjectConfirmation one of the possible request IDs (%v)", possibleRequestIDs)
 		}
 		if subjectConfirmation.SubjectConfirmationData.Recipient != sp.AcsURL.String() {
 			return fmt.Errorf("SubjectConfirmation Recipient is not %s", sp.AcsURL.String())

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/crewjam/saml/testsaml"
+	"github.com/kr/pretty"
 	"github.com/russellhaering/goxmldsig"
 
 	"crypto/rsa"
@@ -697,10 +698,9 @@ func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`Destination` does not match AcsURL (expected \"https://wrong/saml2/acs\")")
 	s.AcsURL = mustParseURL("https://15661444.ngrok.io/saml2/acs")
 
-	// TODO: restore after troubleshooting
-	//req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
-	//_, err = s.ParseResponse(&req, []string{"wrongRequestID"})
-	//c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
+	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
+	_, err = s.ParseResponse(&req, []string{"wrongRequestID"})
+	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`InResponseTo` does not match any of the possible request IDs (expected [wrongRequestID])")
 
 	TimeNow = func() time.Time {
 		rv, _ := time.Parse("Mon Jan 2 15:04:05 MST 2006", "Mon Nov 30 20:57:09 UTC 2016")
@@ -782,10 +782,9 @@ func (test *ServiceProviderTest) TestInvalidAssertions(c *C) {
 	assertion = Assertion{}
 	xml.Unmarshal(assertionBuf, &assertion)
 
-	// TODO: restore after troubleshooting
-	//pretty.Print(assertion.Subject.SubjectConfirmations)
-	//err = s.validateAssertion(&assertion, []string{"any request id"}, TimeNow())
-	//c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
+	pretty.Print(assertion.Subject.SubjectConfirmations)
+	err = s.validateAssertion(&assertion, []string{"any request id"}, TimeNow())
+	c.Assert(err, ErrorMatches, "SubjectConfirmation one of the possible request IDs .*")
 
 	assertion.Subject.SubjectConfirmations[0].SubjectConfirmationData.Recipient = "wrong/acs/url"
 	err = s.validateAssertion(&assertion, []string{"id-9e61753d64e928af5a7a341a97f420c9"}, TimeNow())


### PR DESCRIPTION
**What**
Revert "if InResponseTo check fails, log but do not fail the SAML response" (e79b4586abb76b0f0de1891d07c6e7ed73bfa9e8)

**Why**
We can now handle this error, see sagansystems/supernova#6601 and sagansystems/agent-desktop#9431

