### PR TITLE
Revert SAML mods

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -35,7 +35,6 @@ type Options struct {
 	ForceAuthn        bool
 	MetadataPath      string
 	ACSPath           string
-	Compatibility     saml.IdpCompatibility
 }
 
 // New creates a new Middleware
@@ -66,14 +65,13 @@ func New(opts Options) (*Middleware, error) {
 
 	m := &Middleware{
 		ServiceProvider: saml.ServiceProvider{
-			Key:           opts.Key,
-			Logger:        logr,
-			Certificate:   opts.Certificate,
-			MetadataURL:   metadataURL,
-			AcsURL:        acsURL,
-			IDPMetadata:   opts.IDPMetadata,
-			ForceAuthn:    &opts.ForceAuthn,
-			Compatibility: opts.Compatibility,
+			Key:         opts.Key,
+			Logger:      logr,
+			Certificate: opts.Certificate,
+			MetadataURL: metadataURL,
+			AcsURL:      acsURL,
+			IDPMetadata: opts.IDPMetadata,
+			ForceAuthn:  &opts.ForceAuthn,
 		},
 		AllowIDPInitiated: opts.AllowIDPInitiated,
 		TokenMaxAge:       tokenMaxAge,

--- a/service_provider.go
+++ b/service_provider.go
@@ -81,9 +81,6 @@ type ServiceProvider struct {
 	// ForceAuthn allows you to force re-authentication of users even if the user
 	// has a SSO session at the IdP.
 	ForceAuthn *bool
-
-	// Compatibility allows you to support not fully SAML-compliant IdPs
-	Compatibility IdpCompatibility
 }
 
 // MaxIssueDelay is the longest allowed time between when a SAML assertion is
@@ -406,7 +403,7 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %s", err)
 		return nil, retErr
 	}
-	if !(resp.Destination == "" && sp.Compatibility.AllowEmptyDestination) && resp.Destination != sp.AcsURL.String() {
+	if resp.Destination != sp.AcsURL.String() {
 		retErr.PrivateErr = fmt.Errorf("`Destination` does not match AcsURL (expected %q)", sp.AcsURL.String())
 		return nil, retErr
 	}
@@ -677,9 +674,4 @@ func (sp *ServiceProvider) validateSignature(el *etree.Element) error {
 
 	_, err = validationContext.Validate(el)
 	return err
-}
-
-type IdpCompatibility struct {
-	// AllowEmptyDestination allows for empty `Destiniation` field in the assertion
-	AllowEmptyDestination bool
 }

--- a/service_provider.go
+++ b/service_provider.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/beevik/etree"
@@ -407,7 +406,7 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %s", err)
 		return nil, retErr
 	}
-	if resp.Destination != sp.AcsURL.String() && !(sp.Compatibility.AllowPartialDestination && strings.HasPrefix(sp.AcsURL.String(), resp.Destination)) {
+	if !(resp.Destination == "" && sp.Compatibility.AllowEmptyDestination) && resp.Destination != sp.AcsURL.String() {
 		retErr.PrivateErr = fmt.Errorf("`Destination` does not match AcsURL (expected %q)", sp.AcsURL.String())
 		return nil, retErr
 	}
@@ -681,6 +680,6 @@ func (sp *ServiceProvider) validateSignature(el *etree.Element) error {
 }
 
 type IdpCompatibility struct {
-	// AllowPartialDestination allows for partial or empty `Destination` attribute in SAML response
-	AllowPartialDestination bool
+	// AllowEmptyDestination allows for empty `Destiniation` field in the assertion
+	AllowEmptyDestination bool
 }

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -643,14 +643,14 @@ func (test *ServiceProviderTest) TestCanParseResponse(c *C) {
 	})
 }
 
-func (test *ServiceProviderTest) TestAllowPartialDestination(c *C) {
+func (test *ServiceProviderTest) TestEmptyDestinationAllowed(c *C) {
 	s := ServiceProvider{
 		Key:           test.Key,
 		Certificate:   test.Certificate,
 		MetadataURL:   mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
 		AcsURL:        mustParseURL("https://15661444.ngrok.io/saml2/acs"),
 		IDPMetadata:   &EntityDescriptor{},
-		Compatibility: IdpCompatibility{AllowPartialDestination: true},
+		Compatibility: IdpCompatibility{AllowEmptyDestination: true},
 	}
 	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
 	c.Assert(err, IsNil)
@@ -658,13 +658,6 @@ func (test *ServiceProviderTest) TestAllowPartialDestination(c *C) {
 	samlResponse := destinationRegExp.ReplaceAllString(test.SamlResponse, "")
 
 	req := http.Request{PostForm: url.Values{}}
-	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(samlResponse)))
-	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
-	c.Assert(err, IsNil)
-
-	samlResponse = destinationRegExp.ReplaceAllString(test.SamlResponse, `Destination="https://15661444.ngrok.io"`)
-
-	req = http.Request{PostForm: url.Values{}}
 	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(samlResponse)))
 	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
 	c.Assert(err, IsNil)

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -642,28 +641,6 @@ func (test *ServiceProviderTest) TestCanParseResponse(c *C) {
 		},
 	})
 }
-
-func (test *ServiceProviderTest) TestEmptyDestinationAllowed(c *C) {
-	s := ServiceProvider{
-		Key:           test.Key,
-		Certificate:   test.Certificate,
-		MetadataURL:   mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
-		AcsURL:        mustParseURL("https://15661444.ngrok.io/saml2/acs"),
-		IDPMetadata:   &EntityDescriptor{},
-		Compatibility: IdpCompatibility{AllowEmptyDestination: true},
-	}
-	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
-	c.Assert(err, IsNil)
-
-	samlResponse := destinationRegExp.ReplaceAllString(test.SamlResponse, "")
-
-	req := http.Request{PostForm: url.Values{}}
-	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(samlResponse)))
-	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
-	c.Assert(err, IsNil)
-}
-
-var destinationRegExp = regexp.MustCompile(`Destination=\S+ `)
 
 func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 	s := ServiceProvider{


### PR DESCRIPTION
**What**
Remove modifications for allowing partial destination matching

**Why**
It was assumed it would be needed for Porsche, which turned out not to be the case

This change supports [ch29757]